### PR TITLE
fix: ensure applause audio plays

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@
     </div>
   </div>
 
-  <audio id="aplausos" src="aplausos.mp3" preload="auto"></audio>
+  <audio id="aplausos" src="https://upload.wikimedia.org/wikipedia/commons/5/5a/Applause-8.mp3" preload="auto"></audio>
 
   <script>
     const scriptURL = 'https://script.google.com/macros/s/AKfycbxES1juc38OMrdfogdZxRNA-ssGYpgWqtCIko_fjdi9WvvrRviYqkgWqC3iksB0XI5mww/exec';


### PR DESCRIPTION
## Summary
- point applause audio element to hosted sample

## Testing
- `node - <<'NODE'
const fs=require('fs');const vm=require('vm');const html=fs.readFileSync('index.html','utf8');const start=html.indexOf('function playSound()');const end=html.indexOf('function createConfetti()');const codeSegment=html.slice(start,end);let beepCalled=false;const sandbox={console,applauseAudio:{src:'https://upload.wikimedia.org/wikipedia/commons/5/5a/Applause-8.mp3',currentTime:0,play(){console.log('play invoked');return{catch(){}};}},beep:()=>{beepCalled=true;}};vm.createContext(sandbox);vm.runInContext(codeSegment+'\nplaySound();',sandbox);console.log('beepCalled',beepCalled);
NODE`
- `npm test >/tmp/test.log && tail -n 20 /tmp/test.log` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a6704d3da4832c9ae5dddd3fb61c5c