### PR TITLE
Add Google Apps Script handlers with CORS

### DIFF
--- a/script.gs
+++ b/script.gs
@@ -1,0 +1,14 @@
+function doPost(e) {
+  var json = JSON.parse(e.postData.contents);
+  return ContentService
+    .createTextOutput(JSON.stringify({status: 'ok'}))
+    .setMimeType(ContentService.MimeType.JSON)
+    .setHeader('Access-Control-Allow-Origin', '*');
+}
+
+function doGet(e) {
+  return ContentService
+    .createTextOutput(JSON.stringify({status: 'ok'}))
+    .setMimeType(ContentService.MimeType.JSON)
+    .setHeader('Access-Control-Allow-Origin', '*');
+}


### PR DESCRIPTION
## Summary
- Add Google Apps Script endpoints for POST and GET requests.
- Parse JSON payload and return status JSON with CORS headers.

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a67075cef0832c80f0317ae643b62f