### PR TITLE
Show alerts after registration submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,10 +304,24 @@
 
       initScratchCard(); openOverlay();
 
-      fetch(scriptURL, { method: 'POST', mode: 'no-cors', headers: { 'Content-Type': 'text/plain;charset=utf-8' }, body: JSON.stringify(formData) }).catch(err => console.error('Error Sheets:', err));
-
-      localStorage.setItem('ak-email', formData.email);
-      localStorage.setItem('ak-phone', formData.phone);
+      fetch(scriptURL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/plain;charset=utf-8' },
+        body: JSON.stringify(formData)
+      })
+      .then(response => {
+        if (response.ok) {
+          alert('Registro exitoso');
+          localStorage.setItem('ak-email', formData.email);
+          localStorage.setItem('ak-phone', formData.phone);
+        } else {
+          alert('Error al registrar, por favor inténtalo nuevamente.');
+        }
+      })
+      .catch(err => {
+        console.error('Error Sheets:', err);
+        alert('Error al registrar, por favor inténtalo nuevamente.');
+      });
     });
 
     window.addEventListener('load', initScratchCard);


### PR DESCRIPTION
## Summary
- Display success alert when registration submission succeeds
- Notify user to retry if registration request fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a670764f2c832cbcd55821cfc6b595